### PR TITLE
fix: include missing interaction token in trigger output

### DIFF
--- a/src/handlers/trigger/TriggerEventHandler.ts
+++ b/src/handlers/trigger/TriggerEventHandler.ts
@@ -885,7 +885,7 @@ export class TriggerEventHandler {
         case Events.InteractionCreate:
           const interaction: BaseInteraction = args[0];
 
-          data.interaction = { ...interaction };
+          data.interaction = { ...interaction, token: interaction.token };
 
           break;
 


### PR DESCRIPTION
## Description
This PR addresses an issue where the `interaction.token` was not being included in the output of the Discord Trigger node.

Without the token, users cannot perform manual HTTP requests to the Discord Interaction API (e.g., sending a `type: 4` response manually or using n8n's HTTP Request node for advanced handling).

## Changes
- Added `token` field to the returned JSON object in `TriggerEventHandler.ts`.

## How to test
1. Create a workflow with the Discord Trigger.
2. Trigger a slash command.
3. Observe that the `token` field is now visible in the output JSON.